### PR TITLE
Retained ability to compile and install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,11 +11,13 @@ Check the Caffe issue tracker in case you need help: https://github.com/BVLC/caf
 
 ### Prerequisites
 
+To avoid `ld` linker errors you may symbolize `libhdf5` and `libhdf5_hl` from their install directory to `/usr/local/lib`.
+
 In addition to prerequisites described [here](http://caffe.berkeleyvision.org/installation.html#prerequisites) we are also need:
 
 - `CUDA`. Please install [official CUDA 6.5 binary from nVidia](https://developer.nvidia.com/cuda-zone)
 - `CUDNN for Jetson and CUDA 6.5`. Please [get one from nVidia](https://developer.nvidia.com/cudnn) using your nVidia Developer account.
-- `Google Protobuf v3.0.0`. It needs to be compiled manually. Note that the code cloned from official repository under the `3.0.0` tag doesn't build due to changes in Google.Test `gmock` repositories. You can fix this yourself or use pre-patched version from unofficial repository https://robotics.bmstu.ru/gitlab/jetson-patches/protobuf-3.0.0
+- `Google Protobuf v3.0.0`. It needs to be compiled manually. Note that the code cloned from official repository under the `3.0.0` tag doesn't build due to changes in Google.Test `gmock` repositories. You can fix this yourself or use pre-patched version from unofficial repository https://robotics.bmstu.ru/gitlab/jetson-patches/protobuf-3.0.0 (requires some Python dependencies to be installed).
 - `OpenCV 3.1.0` with some patches. It needs to be compiled too. You may use the [instructions from official OpenCV knowledge base](https://docs.opencv.org/3.3.0/d6/d15/tutorial_building_tegra_cuda.html) or grab pre-patched code from https://robotics.bmstu.ru/gitlab/jetson-patches/OpenCV-3.1.0
 
 ### Building

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,60 @@
 # Installation
 
-See http://caffe.berkeleyvision.org/installation.html for the latest
-installation instructions.
+## Official 
 
-Check the issue tracker in case you need help:
-https://github.com/BVLC/caffe/issues
+See http://caffe.berkeleyvision.org/installation.html for the latest
+installation instructions  for `Caffe` itself.
+
+Check the Caffe issue tracker in case you need help: https://github.com/BVLC/caffe/issues
+
+## Installation of Patched Version on Jetson TK1
+
+### Prerequisites
+
+In addition to prerequisites described [here](http://caffe.berkeleyvision.org/installation.html#prerequisites) we are also need:
+
+- `CUDA`. Please install [official CUDA 6.5 binary from nVidia](https://developer.nvidia.com/cuda-zone)
+- `CUDNN for Jetson and CUDA 6.5`. Please [get one from nVidia](https://developer.nvidia.com/cudnn) using your nVidia Developer account.
+- `Google Protobuf v3.0.0`. It needs to be compiled manually. Note that the code cloned from official repository under the `3.0.0` tag doesn't build due to changes in Google.Test `gmock` repositories. You can fix this yourself or use pre-patched version from unofficial repository https://robotics.bmstu.ru/gitlab/jetson-patches/protobuf-3.0.0
+- `OpenCV 3.1.0` with some patches. It needs to be compiled too. You may use the [instructions from official OpenCV knowledge base](https://docs.opencv.org/3.3.0/d6/d15/tutorial_building_tegra_cuda.html) or grab pre-patched code from https://robotics.bmstu.ru/gitlab/jetson-patches/OpenCV-3.1.0
+
+### Building
+
+Here and below we assume that you keep your `Protobuf` and `OpenCV` installed into `/util` root directory. Also you must set `PATH`, `LD_LIBRARY_PATH`, `PKG_CONFIG_PATH` environment variables to make the compiler available to access your side installations.
+
+If you have another `Protobuf` already installed in system, set the temporary links for `protoc` and `/util/include/google/protobuf` directory using following commands:
+```bash
+sudo mv /usr/include/google/protobuf /usr/include/google/protobuf_backup
+sudo mv /usr/bin/protoc /usr/bin/protoc_backup
+sudo ln -s /util/include/google/protobuf /usr/include/google/protobuf
+sudo ln -s /util/bin/protoc /usr/bin/protoc
+```
+
+Now change the directory to the cloned `caffetk1` and run:
+```bash
+cp Makefile.config.example Makefile.config
+CXXFLAGS="-std=c++11 -I/util/include -L/util/lib" NVCCFLAGS="-std=c++11 -Xcompiler=-fPIC -I/util/include -L/util/lib" LDFLAGS="-L/util/lib" USE_PKG_CONFIG=1 make -j4
+```
+
+After that (if the build process produced no errors) you will have your `Caffe` built. 
+
+Now you can run:
+```bash
+CXXFLAGS="-std=c++11 -I/util/include -L/util/lib" NVCCFLAGS="-std=c++11 -Xcompiler=-fPIC -I/util/include -L/util/lib" LDFLAGS="-L/util/lib" USE_PKG_CONFIG=1 make distribute
+```
+to obtain `distribute` directory which will contain XDG directory tree in which `Caffe` can be deployed on the machine with the same hardware and configuration. Run
+```bash
+./distribute/bin/caffe.bin device_query -gpu 0
+```
+to view the GPU diagnostic message. If you don't see an error message, your `Caffe` is ready for testing.
+
+### Testing
+
+Running tests for `Caffe` on Jetson is quite simple. Just use
+```bash
+CXXFLAGS="-std=c++11 -I/util/include -L/util/lib" NVCCFLAGS="-std=c++11 -Xcompiler=-fPIC -I/util/include -L/util/lib" LDFLAGS="-L/util/lib" USE_PKG_CONFIG=1 make runtest
+```
+
+The testing process duration is about half a hour.
+
+**Congratulations! Your `Caffe for Jetson TK1` is now compiled!**

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,20 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARIES := cudart cublas curand
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
-	lmdb boost_system hdf5_hl hdf5 m \
-	opencv_core opencv_highgui opencv_imgproc
+	lmdb boost_system boost_filesystem hdf5_hl hdf5 m \
+opencv_gapi opencv_stitching opencv_superres opencv_videostab opencv_aruco \
+opencv_bgsegm opencv_bioinspired opencv_ccalib opencv_cudabgsegm opencv_cudacodec \
+opencv_cudafeatures2d opencv_cudaobjdetect opencv_cudaoptflow opencv_cudalegacy \
+opencv_cudastereo opencv_cudawarping opencv_dnn_objdetect opencv_dpm opencv_face \
+opencv_photo opencv_cudaimgproc opencv_cudafilters opencv_freetype opencv_fuzzy \
+opencv_hdf opencv_hfs opencv_img_hash opencv_line_descriptor opencv_optflow opencv_reg \
+opencv_rgbd opencv_saliency opencv_sfm opencv_stereo opencv_structured_light \
+opencv_phase_unwrapping opencv_surface_matching opencv_tracking opencv_video \
+opencv_datasets opencv_text opencv_dnn opencv_plot opencv_xfeatures2d opencv_shape \
+opencv_ml opencv_cudaarithm opencv_ximgproc opencv_calib3d opencv_features2d opencv_highgui \
+opencv_videoio opencv_flann opencv_xobjdetect opencv_imgcodecs opencv_objdetect opencv_xphoto \
+opencv_imgproc opencv_core opencv_cudev
+#opencv_core opencv_highgui opencv_imgproc
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 
@@ -350,14 +362,14 @@ CXXFLAGS += -MMD -MP
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
-NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
+NVCCFLAGS += -ccbin=$(CXX) -Xcompiler $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
 LINKFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
 
 USE_PKG_CONFIG ?= 0
 ifeq ($(USE_PKG_CONFIG), 1)
-	PKG_CONFIG := $(shell pkg-config opencv --libs)
+	PKG_CONFIG := $(shell pkg-config opencv --libs --cflags)
 else
 	PKG_CONFIG :=
 endif

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -2,7 +2,7 @@
 # Contributions simplifying and improving our build system are welcome!
 
 # cuDNN acceleration switch (uncomment to build with cuDNN).
-# USE_CUDNN := 1
+USE_CUDNN := 1
 
 # CPU-only switch (uncomment to build without GPU support).
 # CPU_ONLY := 1
@@ -12,7 +12,7 @@
 # CUSTOM_CXX := g++
 
 # CUDA directory contains bin/ and lib/ directories that we need.
-CUDA_DIR := /usr/local/cuda
+CUDA_DIR := /usr/local/cuda-6.5
 # On Ubuntu 14.04, if cuda tools are installed via
 # "sudo apt-get install nvidia-cuda-toolkit" then use this instead:
 # CUDA_DIR := /usr

--- a/README.md
+++ b/README.md
@@ -26,10 +26,17 @@ The BVLC reference models are released for unrestricted use.
 
 Please cite Caffe in your publications if it helps your research:
 
-    @article{jia2014caffe,
-      Author = {Jia, Yangqing and Shelhamer, Evan and Donahue, Jeff and Karayev, Sergey and Long, Jonathan and Girshick, Ross and Guadarrama, Sergio and Darrell, Trevor},
-      Journal = {arXiv preprint arXiv:1408.5093},
-      Title = {Caffe: Convolutional Architecture for Fast Feature Embedding},
-      Year = {2014}
-    }
+```bibtex
+@inproceedings{jia2014caffe,
+  title={Caffe: Convolutional architecture for fast feature embedding},
+  author={Jia, Yangqing and Shelhamer, Evan and Donahue, Jeff and Karayev, Sergey and Long, Jonathan and Girshick, Ross and Guadarrama, Sergio and Darrell, Trevor},
+  booktitle={Proceedings of the 22nd ACM international conference on Multimedia},
+  pages={675--678},
+  year={2014},
+  organization={ACM}
+}
+```
+    
 # caffetk1
+
+This patched version of Caffe is fully dedicated to be built on [nVidia Jetson TK1](https://www.nvidia.com/object/jetson-tk1-embedded-dev-kit.html). See the unofficial installation tutorial here: https://github.com/twdragon/caffetk1/blob/master/INSTALL.md

--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -186,13 +186,13 @@ void Classifier::Preprocess(const cv::Mat& img,
   /* Convert the input image to the input image format of the network. */
   cv::Mat sample;
   if (img.channels() == 3 && num_channels_ == 1)
-    cv::cvtColor(img, sample, CV_BGR2GRAY);
+    cv::cvtColor(img, sample, cv::COLOR_BGR2GRAY);
   else if (img.channels() == 4 && num_channels_ == 1)
-    cv::cvtColor(img, sample, CV_BGRA2GRAY);
+    cv::cvtColor(img, sample, cv::COLOR_BGRA2GRAY);
   else if (img.channels() == 4 && num_channels_ == 3)
-    cv::cvtColor(img, sample, CV_BGRA2BGR);
+    cv::cvtColor(img, sample, cv::COLOR_BGRA2BGR);
   else if (img.channels() == 1 && num_channels_ == 3)
-    cv::cvtColor(img, sample, CV_GRAY2BGR);
+    cv::cvtColor(img, sample, cv::COLOR_GRAY2BGR);
   else
     sample = img;
 

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -86,7 +86,8 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     CHECK_EQ(mkdir(db_path, 0744), 0)
         << "mkdir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
-    CHECK_EQ(mdb_env_set_mapsize(mdb_env, 1099511627776), MDB_SUCCESS)  // 1TB
+    //CHECK_EQ(mdb_env_set_mapsize(mdb_env, 1099511627776), MDB_SUCCESS)  // 1TB
+    CHECK_EQ(mdb_env_set_mapsize(mdb_env, 536870912), MDB_SUCCESS) 
         << "mdb_env_set_mapsize failed";
     CHECK_EQ(mdb_env_open(mdb_env, db_path, 0, 0664), MDB_SUCCESS)
         << "mdb_env_open failed";

--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -6,8 +6,8 @@
 
 namespace caffe { namespace db {
 
-const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
-
+//const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
+const size_t LMDB_MAP_SIZE = 536870912;
 void LMDB::Open(const string& source, Mode mode) {
   MDB_CHECK(mdb_env_create(&mdb_env_));
   MDB_CHECK(mdb_env_set_mapsize(mdb_env_, LMDB_MAP_SIZE));


### PR DESCRIPTION
Retained ability to compile and install Caffe on Jetson TK1 using right versions of dependency libraries, especially `OpenCV` (the standard very old `OpenCV4Tegra` is quite unsuitable for some applications, inc. ROS) and `Google Protobuf`. The framework is now able to be built, tested and installed properly using unofficial repos and pre-patched open source code.

Also some magic constants and build scripts are changed according to current toolchain requirements.